### PR TITLE
Disable no-onchange lint rule

### DIFF
--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -27,6 +27,7 @@
     "react/prop-types": "off",
     "react/react-in-jsx-scope": "off",
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn"
+    "react-hooks/exhaustive-deps": "warn",
+    "jsx-a11y/no-onchange": "off"
   }
 }

--- a/web/src/pages/setup.js
+++ b/web/src/pages/setup.js
@@ -89,7 +89,7 @@ export default function SetupPage({ locations }) {
             name="location"
             id="location"
             value={locationId}
-            onBlur={(e) => setLocationId(e.target.value)}
+            onChange={(e) => setLocationId(e.target.value)}
           >
             <option hidden value={undefined}>
               -
@@ -121,7 +121,7 @@ export default function SetupPage({ locations }) {
             name="program"
             id="program"
             value={programId}
-            onBlur={(e) => setProgramId(e.target.value)}
+            onChange={(e) => setProgramId(e.target.value)}
           >
             <option hidden value={undefined}>
               -


### PR DESCRIPTION
This rule is deprecated but haven't made its way into the latest version of `eslint-plugin-jsx-a11y` yet.